### PR TITLE
Fix Apache license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/TomerAberbach/parse-imports/issues"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
The license field in package.json should be using the appropriate SPDX license identifier as described in the NPM [docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license).

The [SPDX identifier for the Apache 2.0 license](https://spdx.org/licenses/Apache-2.0.html) is `Apache-2.0`. Our automated license checker was not correctly validating this repo as using an approved license.